### PR TITLE
Explicit open input .xml file with UTF-8 encoding

### DIFF
--- a/biliass/__main__.py
+++ b/biliass/__main__.py
@@ -70,8 +70,11 @@ def main():
     inputs = []
     for file in args.file:
         try:
-            with open(file, "r" if args.format == "xml" else "rb") as f:
-                inputs.append(f.read())
+            if args.format == "xml":
+                f = open(file, "r", encoding = "utf-8")
+            else:
+                f = open(file, "rb")
+            inputs.append(f.read())
         except UnicodeDecodeError:
             logging.error(f"Failed to decode file {file}, if it is a protobuf file, please use `-f protobuf`")
             sys.exit(1)


### PR DESCRIPTION
My system (Windows 10) doesn't open .xml with UTF-8 encoding by default, hence it's always failed with:
```
Failed to decode file myfile.xml, if it is a protobuf file, please use `-f protobuf`
```